### PR TITLE
GitHub Action for building&publishing executables

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,11 +29,14 @@ jobs:
       - name: Building a binary
         run: gfortran -march=native -O3 --static bift.f -o bift-${BIFT_VER}-linux
 
+      - name: Show directory contents
+        run: ls -l
+
       - name: Provide the binary on a always updating single release page on GitHub
         uses: softprops/action-gh-release@v1
         with:
           tag_name: latest
-          files: bift-${BIFT_VER}-linux
+          files: bift-${{env.BIFT_VER}}-linux
 
   build-windows:
     # The type of runner that the job will run on
@@ -50,11 +53,14 @@ jobs:
       - name: Building a binary
         run: C:\msys64\msys2_shell.cmd -mingw64 -defterm -here -full-path -no-start -shell bash -c "x86_64-w64-mingw32-gfortran -march=native -O3 --static bift.f -o bift-${BIFT_VER}-windows.exe"
 
+      - name: Show directory contents
+        run: ls -l
+
       - name: Provide the binary on a always updating single release page on GitHub
         uses: softprops/action-gh-release@v1
         with:
           tag_name: latest
-          files: bift-${BIFT_VER}-windows.exe
+          files: bift-${{env.BIFT_VER}}-windows.exe
 
   build-macos:
     # The type of runner that the job will run on
@@ -78,8 +84,11 @@ jobs:
             $(find $GCC_PATH -name libgfortran.a -or -name libgcc.a -or -name libquadmath.a) \
             bift.o -o bift-${BIFT_VER}-macos
 
+      - name: Show directory contents
+        run: ls -l
+
       - name: Provide the binary on a always updating single release page on GitHub
         uses: softprops/action-gh-release@v1
         with:
           tag_name: latest
-          files: bift-${BIFT_VER}-macos
+          files: bift-${{env.BIFT_VER}}-macos

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Building a binary
-        run: gfortran -march=native -O3 --static bift.f -o bift
+        run: gfortran -march=native -O3 --static bift.f -o bift-linux
 
       - name: Provide the binary on a always updating single release page on GitHub
         uses: softprops/action-gh-release@v1
         with:
           tag_name: latest
-          files: bift
+          files: bift-linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,3 +49,23 @@ jobs:
         with:
           tag_name: latest
           files: bift-windows.exe
+
+  build-macos:
+    # The type of runner that the job will run on
+    runs-on: macos-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Building a binary
+        run: |
+          which gfortran; gfortran --version
+          gfortran -march=native -O3 --static bift.f -o bift-macos
+
+      - name: Provide the binary on a always updating single release page on GitHub
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: latest
+          files: bift-macos

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,10 @@ jobs:
         run: echo "BIFT_VER=$(git log -1 --date=format:'%y%m%d' --format='%ad-%h')" >> $GITHUB_ENV
 
       - name: Building a binary
-        run: C:\msys64\msys2_shell.cmd -mingw64 -defterm -here -full-path -no-start -shell bash -c "x86_64-w64-mingw32-gfortran -march=native -O3 --static bift.f -o bift-${BIFT_VER}-windows.exe"
+        run: C:\msys64\msys2_shell.cmd -mingw64 -defterm -here -full-path -no-start -shell bash -c "x86_64-w64-mingw32-gfortran -march=native -O3 --static bift.f -o bift-windows.exe"
+
+      - name: Renaming the binary to a versioned name
+        run: rename bift-windows.exe bift-${{env.BIFT_VER}}-windows.exe
 
       - name: Show directory contents
         run: dir

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,14 +23,17 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
+      - name: Add BIFT_VER environment property
+        run: echo "BIFT_VER=$(git log -1 --date=format:'%y%m%d' --format='%ad-%h')" >> $GITHUB_ENV
+
       - name: Building a binary
-        run: gfortran -march=native -O3 --static bift.f -o bift-linux
+        run: gfortran -march=native -O3 --static bift.f -o bift-${BIFT_VER}-linux
 
       - name: Provide the binary on a always updating single release page on GitHub
         uses: softprops/action-gh-release@v1
         with:
           tag_name: latest
-          files: bift-linux
+          files: bift-${BIFT_VER}-linux
 
   build-windows:
     # The type of runner that the job will run on
@@ -41,14 +44,17 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
+      - name: Add BIFT_VER environment property
+        run: echo "BIFT_VER=$(git log -1 --date=format:'%y%m%d' --format='%ad-%h')" >> $GITHUB_ENV
+
       - name: Building a binary
-        run: C:\msys64\msys2_shell.cmd -mingw64 -defterm -here -full-path -no-start -shell bash -c "x86_64-w64-mingw32-gfortran -march=native -O3 --static bift.f -o bift-windows.exe"
+        run: C:\msys64\msys2_shell.cmd -mingw64 -defterm -here -full-path -no-start -shell bash -c "x86_64-w64-mingw32-gfortran -march=native -O3 --static bift.f -o bift-${BIFT_VER}-windows.exe"
 
       - name: Provide the binary on a always updating single release page on GitHub
         uses: softprops/action-gh-release@v1
         with:
           tag_name: latest
-          files: bift-windows.exe
+          files: bift-${BIFT_VER}-windows.exe
 
   build-macos:
     # The type of runner that the job will run on
@@ -59,6 +65,9 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
+      - name: Add BIFT_VER environment property
+        run: echo "BIFT_VER=$(git log -1 --date=format:'%y%m%d' --format='%ad-%h')" >> $GITHUB_ENV
+
       - name: Building the code
         run: gfortran-10 -march=native -O3 -c bift.f
 
@@ -67,10 +76,10 @@ jobs:
           GCC_PATH="$(dirname $(gfortran-10 -print-libgcc-file-name))/../../.."
           clang -Wl,-no_compact_unwind \
             $(find $GCC_PATH -name libgfortran.a -or -name libgcc.a -or -name libquadmath.a) \
-            bift.o -o bift-macos
+            bift.o -o bift-${BIFT_VER}-macos
 
       - name: Provide the binary on a always updating single release page on GitHub
         uses: softprops/action-gh-release@v1
         with:
           tag_name: latest
-          files: bift-macos
+          files: bift-${BIFT_VER}-macos

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Provide the binary on a always updating single release page on GitHub
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: latest
+          tag_name: ${{env.BIFT_VER}}
           files: bift-${{env.BIFT_VER}}-linux
 
   build-windows:
@@ -62,7 +62,7 @@ jobs:
       - name: Provide the binary on a always updating single release page on GitHub
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: latest
+          tag_name: ${{env.BIFT_VER}}
           files: bift-${{env.BIFT_VER}}-windows.exe
 
   build-macos:
@@ -93,5 +93,5 @@ jobs:
       - name: Provide the binary on a always updating single release page on GitHub
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: latest
+          tag_name: ${{env.BIFT_VER}}
           files: bift-${{env.BIFT_VER}}-macos

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Installing a Fortran compiler first
-        run: pacman -S --noconfirm --needed mingw64/mingw-w64-x86_64-gcc-fortran
+        run: pacman.exe -S --noconfirm --needed mingw64/mingw-w64-x86_64-gcc-fortran
 
       - name: Building a binary
         run: gfortran -march=native -O3 --static bift.f -o bift-windows.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,12 +62,15 @@ jobs:
       - name: Building the code
         run: gfortran-10 -march=native -O3 -c bift.f
 
+      - name: Show libaries location
+        run: gfortran-10 -print-libgcc-file-name
+
       - name: Testing if static libs are found
-        run: find /usr/local/lib/gcc/10 -name libgfortran.a -or -name libgcc.a -or -name libquadmath.a
+        run: find "$(realpath $(dirname $(gfortran-10 -print-libgcc-file-name))/../../../)" -name libgfortran.a -or -name libgcc.a -or -name libquadmath.a
 
       - name: Linking to a binary
         run: |
-          GCC_PATH=/usr/local/lib/gcc/10
+          GCC_PATH="$(realpath $(dirname $(gfortran-10 -print-libgcc-file-name))/../../../)"
           clang -Wl,-no_compact_unwind \
             $(find $GCC_PATH -name libgfortran.a -or -name libgcc.a -or -name libquadmath.a) \
             bift.o -o bift-macos

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
         run: C:\msys64\msys2_shell.cmd -mingw64 -defterm -here -full-path -no-start -shell bash -c "x86_64-w64-mingw32-gfortran -march=native -O3 --static bift.f -o bift-${BIFT_VER}-windows.exe"
 
       - name: Show directory contents
-        run: ls -l
+        run: dir
 
       - name: Provide the binary on a always updating single release page on GitHub
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Building a binary
+        run: gfortran -march=native -O3 --static bift.f -o bift
+
+      - name: Provide the binary on a always updating single release page on GitHub
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: latest
+          files: bift

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,8 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
+
+  build-linux:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
@@ -31,3 +31,24 @@ jobs:
         with:
           tag_name: latest
           files: bift-linux
+
+  build-windows:
+    # The type of runner that the job will run on
+    runs-on: windows-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Installing a Fortran compiler first
+        run: pacman -S --noconfirm --needed mingw64/mingw-w64-x86_64-gcc-fortran
+
+      - name: Building a binary
+        run: gfortran -march=native -O3 --static bift.f -o bift-windows.exe
+
+      - name: Provide the binary on a always updating single release page on GitHub
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: latest
+          files: bift-windows.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,12 +41,8 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - name: Installing a Fortran compiler in MinGW64 environment first
-        run: |
-          C:\msys64\msys2_shell.cmd -mingw64 -defterm -here -full-path -no-start -shell bash -c "pacman -S --noconfirm --needed mingw-w64-x86_64-gcc-fortran"
-
       - name: Building a binary
-        run: gfortran -march=native -O3 --static bift.f -o bift-windows.exe
+        run: C:\msys64\msys2_shell.cmd -mingw64 -defterm -here -full-path -no-start -shell bash -c "x86_64-w64-mingw32-gfortran -march=native -O3 --static bift.f -o bift-windows.exe"
 
       - name: Provide the binary on a always updating single release page on GitHub
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
         run: gfortran-10 -print-libgcc-file-name
 
       - name: Testing if static libs are found
-        run: find "$(realpath $(dirname $(gfortran-10 -print-libgcc-file-name))/../../../)" -name libgfortran.a -or -name libgcc.a -or -name libquadmath.a
+        run: find "$(dirname $(gfortran-10 -print-libgcc-file-name))/../../.." -name libgfortran.a -or -name libgcc.a -or -name libquadmath.a
 
       - name: Linking to a binary
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,8 +61,8 @@ jobs:
 
       - name: Building a binary
         run: |
-          which gfortran; gfortran --version
-          gfortran -march=native -O3 --static bift.f -o bift-macos
+          which gfortran-10; gfortran-10 --version
+          gfortran-10 -march=native -O3 --static bift.f -o bift-macos
 
       - name: Provide the binary on a always updating single release page on GitHub
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
         run: C:\msys64\msys2_shell.cmd -mingw64 -defterm -here -full-path -no-start -shell bash -c "x86_64-w64-mingw32-gfortran -march=native -O3 --static bift.f -o bift-windows.exe"
 
       - name: Renaming the binary to a versioned name
-        run: rename bift-windows.exe bift-${{env.BIFT_VER}}-windows.exe
+        run: mv bift-windows.exe bift-${{env.BIFT_VER}}-windows.exe
 
       - name: Show directory contents
         run: dir

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,10 +59,18 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - name: Building a binary
+      - name: Building the code
+        run: gfortran-10 -march=native -O3 -c bift.f
+
+      - name: Testing if static libs are found
+        run: find /usr/local/lib/gcc/10 -name libgfortran.a -or -name libgcc.a -or -name libquadmath.a
+
+      - name: Linking to a binary
         run: |
-          which gfortran-10; gfortran-10 --version
-          gfortran-10 -march=native -O3 --static bift.f -o bift-macos
+          GCC_PATH=/usr/local/lib/gcc/10
+          clang -Wl,-no_compact_unwind \
+            $(find $GCC_PATH -name libgfortran.a -or -name libgcc.a -or -name libquadmath.a) \
+            bift.o -o bift-macos
 
       - name: Provide the binary on a always updating single release page on GitHub
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,15 +62,9 @@ jobs:
       - name: Building the code
         run: gfortran-10 -march=native -O3 -c bift.f
 
-      - name: Show libaries location
-        run: gfortran-10 -print-libgcc-file-name
-
-      - name: Testing if static libs are found
-        run: find "$(dirname $(gfortran-10 -print-libgcc-file-name))/../../.." -name libgfortran.a -or -name libgcc.a -or -name libquadmath.a
-
       - name: Linking to a binary
         run: |
-          GCC_PATH="$(realpath $(dirname $(gfortran-10 -print-libgcc-file-name))/../../../)"
+          GCC_PATH="$(dirname $(gfortran-10 -print-libgcc-file-name))/../../.."
           clang -Wl,-no_compact_unwind \
             $(find $GCC_PATH -name libgfortran.a -or -name libgcc.a -or -name libquadmath.a) \
             bift.o -o bift-macos

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Add BIFT_VER environment property
-        run: echo "BIFT_VER=$(git log -1 --date=format:'%y%m%d' --format='%ad-%h')" >> $GITHUB_ENV
+        run: echo "BIFT_VER=$(git log -1 --date=format:'%y%m%d' --format='%ad-%h')" >> $env:GITHUB_ENV
 
       - name: Building a binary
         run: C:\msys64\msys2_shell.cmd -mingw64 -defterm -here -full-path -no-start -shell bash -c "x86_64-w64-mingw32-gfortran -march=native -O3 --static bift.f -o bift-windows.exe"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,9 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - name: Installing a Fortran compiler first
-        run: pacman.exe -S --noconfirm --needed mingw64/mingw-w64-x86_64-gcc-fortran
+      - name: Installing a Fortran compiler in MinGW64 environment first
+        run: |
+          C:\msys64\msys2_shell.cmd -mingw64 -defterm -here -full-path -no-start -shell bash -c "pacman -S --noconfirm --needed mingw-w64-x86_64-gcc-fortran"
 
       - name: Building a binary
         run: gfortran -march=native -O3 --static bift.f -o bift-windows.exe


### PR DESCRIPTION
Thanks for publishing this great program! I added a configuration file for GitHub Actions to let it build binaries for Windows, Linux and macOS every time the code is updated. There is a new tag and release created for providing the respective binary versions.
There are many commits but I needed some tries to get it working ;)
Perhaps, it lowers the barrier a bit for people who want to try it out but who are not familiar with compiling FORTRAN code - Thanks!